### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -18,9 +18,9 @@ process	KEYWORD2
 registerCommand	KEYWORD2
 unregisterCommand	KEYWORD2
 stats	KEYWORD2
-broadcast KEYWORD2
-isBroadCast KEYWORD2
-isRelay KEYWORD2
+broadcast	KEYWORD2
+isBroadCast	KEYWORD2
+isRelay	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords